### PR TITLE
ZMQ Serial driver

### DIFF
--- a/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
+++ b/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
@@ -1,0 +1,80 @@
+from lightlab.equipment.visa_bases import ZMQSerial
+
+import numpy as np
+from IPython.display import clear_output
+import serial
+
+baud = 115200
+port = "/dev/ttyACM0"
+timeout = 2
+
+x = "x"
+y = "y"
+z = "z"
+
+
+class MDT693B_OLPC(ZMQSerial):
+    ''' A MDT693B - 3-Channel, Open-Loop Piezo Controller 
+
+    Uses the remote serial interface
+
+        `Manual: <https://www.thorlabs.com/thorproduct.cfm?partnumber=MDT693B>`__
+
+        Usage: : TODO
+
+    '''
+
+    def __init__(self, name=None, server_user=None, server_address=None, **kwargs):
+        '''
+            Args:
+                currStep (float): amount to step if ramping in current mode. Default (None) is no ramp
+                voltStep (float): amount to step if ramping in voltage mode. Default (None) is no ramp
+                rampStepTime (float): time to wait on each ramp step point
+        '''
+        ZMQSerial.__init__(self, name=name, server_user=server_user, server_address=server_address, **kwargs)
+
+
+# # send command and return the controller's response
+# def command(cmd):
+#     cmd += "\n"
+#     with serial.Serial(port, baud, timeout=timeout) as ser:
+#         ser.write(cmd.encode())
+#         recv = ser.readlines()
+#         recv_list = []
+#         for recvi in recv:
+#             recv_list.append(recvi.decode())
+#     return recv_list[1]
+
+# def get_volt(axis):
+#     cmd = "{}voltage?\n".format(axis)
+#     with serial.Serial(port, baud, timeout=timeout) as ser:
+#         ser.write(cmd.encode())
+#         recv = ser.readlines()
+#         recv_list = []
+#         for recvi in recv:
+#             recv_list.append(recvi.decode())
+#     volt = float(recv_list[1].strip('[]\r> '))
+#     return volt
+
+# def set_volt(axis, volt):
+#     cmd = "{}voltage={}\n".format(axis, volt)
+#     with serial.Serial(port, baud, timeout=timeout) as ser:
+#         ser.write(cmd.encode())
+#     return
+
+# def increase(axis, dv):
+#     with serial.Serial(port, baud, timeout=timeout) as ser:
+#         cmd = "{}voltage?\n".format(axis)
+#         ser.write(cmd.encode())
+#         recv = ser.readline().decode()
+#         volt = float(recv.strip('[]\r> '))
+#         cmd = "{}voltage={}\n".format(axis, volt+dv)
+#         ser.write(cmd.encode())
+#     return 
+
+
+"""
+Example use
+"""
+if __name__ == '__main__':
+    stage = MDT693B_OLPC(name='stage', server_address='128.112.50.75', server_user='pi')

--- a/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
+++ b/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
@@ -61,9 +61,9 @@ if __name__ == '__main__':
     import time
     import sys
     stage = MDT693B_OLPC(name='stage', server_address='128.112.50.75', server_user='pi')
-    # print(stage.set_volt('x', 12))
-    # print(stage.get_volt('x'))
-    # print(stage.ping())
-    # print(stage.terminate())
+    print(stage.set_volt('x', 12))
+    print(stage.get_volt('x'))
+    print(stage.ping())
+    print(stage.terminate())
     print(stage.ping())
     sys.exit()

--- a/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
+++ b/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
@@ -1,4 +1,4 @@
-from lightlab.equipment.visa_bases import ZMQSerial
+from lightlab.equipment.visa_bases import ZMQSerial_driver
 
 import numpy as np
 from IPython.display import clear_output
@@ -13,7 +13,7 @@ y = "y"
 z = "z"
 
 
-class MDT693B_OLPC(ZMQSerial):
+class MDT693B_OLPC(ZMQSerial_driver):
     ''' A MDT693B - 3-Channel, Open-Loop Piezo Controller 
 
     Uses the remote serial interface
@@ -31,7 +31,7 @@ class MDT693B_OLPC(ZMQSerial):
                 voltStep (float): amount to step if ramping in voltage mode. Default (None) is no ramp
                 rampStepTime (float): time to wait on each ramp step point
         '''
-        ZMQSerial.__init__(self, name=name, server_user=server_user, server_address=server_address, **kwargs)
+        ZMQSerial_driver.__init__(self, name=name, server_user=server_user, server_address=server_address, **kwargs)
 
 
 # # send command and return the controller's response

--- a/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
+++ b/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
@@ -27,11 +27,12 @@ class MDT693B_OLPC(ZMQclient):
     def __init__(self, name=None, server_user=None, server_address=None, **kwargs):
         '''
             Args:
-                currStep (float): amount to step if ramping in current mode. Default (None) is no ramp
-                voltStep (float): amount to step if ramping in voltage mode. Default (None) is no ramp
-                rampStepTime (float): time to wait on each ramp step point
         '''
-        ZMQclient.__init__(self, name=name, server_user=server_user, server_address=server_address, **kwargs)
+        ZMQclient.__init__(self, 
+                            name=name, 
+                            server_user=server_user, 
+                            server_address=server_address, 
+                            **kwargs)
 
 
     def get_volt(self, axis):
@@ -61,3 +62,6 @@ if __name__ == '__main__':
     stage = MDT693B_OLPC(name='stage', server_address='128.112.50.75', server_user='pi')
     print(stage.set_volt('x', 12))
     print(stage.get_volt('x'))
+    print(stage.ping())
+    print(stage.terminate())
+    print(stage.ping())

--- a/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
+++ b/lightlab/equipment/lab_instruments/MDT693B_OLPC.py
@@ -59,9 +59,11 @@ Example use
 """
 if __name__ == '__main__':
     import time
+    import sys
     stage = MDT693B_OLPC(name='stage', server_address='128.112.50.75', server_user='pi')
-    print(stage.set_volt('x', 12))
-    print(stage.get_volt('x'))
+    # print(stage.set_volt('x', 12))
+    # print(stage.get_volt('x'))
+    # print(stage.ping())
+    # print(stage.terminate())
     print(stage.ping())
-    print(stage.terminate())
-    print(stage.ping())
+    sys.exit()

--- a/lightlab/equipment/visa_bases/__init__.py
+++ b/lightlab/equipment/visa_bases/__init__.py
@@ -1,3 +1,3 @@
 from .visa_object import VISAObject  # noqa
 from .visa_driver import IncompleteClass, VISAInstrumentDriver, DefaultDriver  # noqa
-from .remote_serial_driver import ZMQSerial_driver
+from .remote_serial_driver import ZMQclient

--- a/lightlab/equipment/visa_bases/__init__.py
+++ b/lightlab/equipment/visa_bases/__init__.py
@@ -1,2 +1,3 @@
 from .visa_object import VISAObject  # noqa
 from .visa_driver import IncompleteClass, VISAInstrumentDriver, DefaultDriver  # noqa
+from .remote_serial_driver import ZMQSerial_driver

--- a/lightlab/equipment/visa_bases/remote_serial_driver.py
+++ b/lightlab/equipment/visa_bases/remote_serial_driver.py
@@ -102,7 +102,7 @@ class ZMQSerial_driver():
                c.run("mkdir ./tmp")
             c.put(__file__, './tmp/serial_server.py')
             c.run("tmux new -d -s zeromq")
-            c.run(f"tmux send-keys -t zeromq.0 \"python ~/tmp/serial_server.py {self.zmq_port} {self.zmq_timeout} {self.serial_port} {self.serial_baud} {self.serial_timeout} > ~/tmp/serial_server.log\" ENTER")
+            c.run(f"tmux send-keys -t zeromq.0 \"python ~/tmp/serial_server.py {self.zmq_port} {self.zmq_timeout} {self.serial_port} {self.serial_baud} {self.serial_timeout} > ./tmp/serial_server.log\" ENTER")
 
     def request(self, command):
         ''' General-purpose Request-Reply with client
@@ -183,7 +183,7 @@ class ZMQserver():
         try:    
             while True:
                 print("In loop")
-                cmd = self.zmq_port.recv()
+                cmd = socket.recv()
                 print("Received command: %s" % cmd)
                 
                 try:
@@ -199,15 +199,16 @@ class ZMQserver():
                 # If communication error
                 except Exception as e:
                     print("Communication error!")
-                    os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
+                    # os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
                     print(e)
+                    return
 
         # If server fails for any other reason (including KeyboardInterrupt)
         except Exception as e:
             # Exit to clean exit command
             print(e)
             print("Server exiting; shutting down tmux session")
-            os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
+            # os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
             return
 
 

--- a/lightlab/equipment/visa_bases/remote_serial_driver.py
+++ b/lightlab/equipment/visa_bases/remote_serial_driver.py
@@ -136,6 +136,7 @@ class ZMQSerial_driver():
 class ZMQserver():
     '''
         Actual class implementing the ZMQ server, to be executed on the remote machine
+        Receives messages from the ZMQ client, and forwards them to the Serial instrument
     '''
     def __init__(self, 
                 # ZMQ settings
@@ -153,6 +154,7 @@ class ZMQserver():
         self.serial_baud = serial_baud
         self.serial_timeout = serial_timeout
 
+        print("Creating zmq")
         context = zmq.Context()
         socket = context.socket(zmq.REP)
         socket.bind(f"tcp://*:{zmq_port}")
@@ -180,7 +182,7 @@ class ZMQserver():
         print("Starting server")        
         try:    
             while True:
-            
+                print("In loop")
                 cmd = self.zmq_port.recv()
                 print("Received command: %s" % cmd)
                 
@@ -197,11 +199,15 @@ class ZMQserver():
                 # If communication error
                 except Exception as e:
                     print("Communication error!")
+                    os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
                     print(e)
 
         # If server fails for any other reason (including KeyboardInterrupt)
-        except:
+        except Exception as e:
             # Exit to clean exit command
+            print(e)
+            print("Server exiting; shutting down tmux session")
+            os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
             return
 
 

--- a/lightlab/equipment/visa_bases/remote_serial_driver.py
+++ b/lightlab/equipment/visa_bases/remote_serial_driver.py
@@ -59,10 +59,11 @@ class ZMQclient():
         self.serial_timeout = serial_timeout
 
         # If the ZMQ server is not already up, start it
-        # if not self.ping():
-            # First destroy any identically-named tmux sessions
-        print(f"Starting server {self.zmq_port} on {self.server_user}:{self.server_address}")
-        self.create_server()
+        if not self.ping():
+            print(f"Starting server {self.zmq_port} on {self.server_user}:{self.server_address}")
+            self.create_server()
+        else:
+            print(f"Successfully pinged {self.zmq_port} on {self.server_user}:{self.server_address}")
 
     def create_server(self):
         '''
@@ -181,7 +182,7 @@ class ZMQserver():
         # Clean exit if "run" function is interrupted and returns
         socket.close()
         context.destroy()
-        # os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
+        os.system('tmux kill-session -t $(tmux display-message -p \'#S\')')
 
     def serial_request(self, cmd, timeout):
         cmd += "\n"

--- a/lightlab/equipment/visa_bases/remote_serial_driver.py
+++ b/lightlab/equipment/visa_bases/remote_serial_driver.py
@@ -1,0 +1,227 @@
+# zmq
+import time
+import zmq
+
+import numpy as np
+from IPython.display import clear_output
+import serial
+
+import sys
+import os
+
+
+class ZMQSerial_driver():
+    '''
+        Generic class for a serial driver interfaced with a "server" machine (e.g.  RPi), while the user issues commands from a "client" machine (e.g. laboratory instrumentation server), using ZMQ for client-server communication
+
+        User <--> [Client] <--ZMQ--> [Server] <--Serial--> Instrument
+
+        - This class provides the utilities that will spawn a zmq process on the server and relay commands from the client
+        - SSH password needs to be input during function call if passwordless connection is not setup
+    '''
+
+    def __init__(self, 
+                name=None,
+                # Server SSH settings
+                server_user=None, # Username for login on the server
+                server_address=None, # IP address of the server
+                server_filename='~/tmp/server.py', # script name to save to remote
+                server_OS_type='debian', # debian (Ubuntu, Raspbian, etc.), ...
+                # ZMQ settings
+                zmq_port=5556, # TCP socket that zmq will use to relay commands
+                zmq_timeout=30, # timeout for server <--> client communication
+                # Serial equipment settings
+                serial_port="/dev/ttyACM0", # Serial port the instrument is connected to on the server (e.g. COM0, "/dev/ttyACM0", etc.)
+                serial_baud=115200, # serial baud rate
+                serial_timeout=5, # timeout for server <--> instrument communication
+            ):
+
+        # Server settings
+        self.server_user = server_user
+        self.server_address = server_address
+        self.server_filename = server_filename      
+        self.server_OS_type = server_OS_type  
+
+        # zmq settings
+        self.zmq_port = zmq_port
+        self.zmq_timeout = zmq_timeout
+
+        # Serial settings
+        self.serial_port = serial_port
+        self.serial_baud = serial_baud
+        self.serial_timeout = serial_timeout
+
+        # If the ZMQ server is not already up, start it
+        if not self.ping_server():
+            self.spawn_server(server_user, server_address, server_OS_type)
+
+    def ping_server(self):
+        '''
+        Returns whether the ZMQ server is already running on the server
+        '''
+        return False # self.request(self, 'ping')
+
+    def spawn_server(self, server_user, server_address, server_OS_type):
+        '''
+        Spawns the server process on the server machine
+        '''
+        # Upload the server code on the server
+        # try:
+        # From https://stackoverflow.com/questions/20499074/run-local-python-script-on-remote-server
+        # Connect to remote host
+        # import paramiko
+        # client = paramiko.SSHClient()
+        # client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # TODO: figure out key situation. For now, just request password:
+        # import getpass
+        # server_password = getpass.getpass()
+        # client.connect(hostname=server_address,
+        #                     username=server_user,
+        #                     password=server_password)
+        # Setup sftp connection and transmit this script
+        # sftp = client.open_sftp()
+        # try:
+        #     sftp.stat('./tmp')
+        # except FileNotFoundError:
+        #     sftp.mkdir('./tmp')
+        # sftp.put(__file__, './tmp/serial_server.py', confirm=False)
+        # sftp.close()
+        # Run the transmitted script remotely without args and show its output.
+        # SSHClient.exec_command() returns the tuple (stdin,stdout,stderr)
+        # client.exec_command('tmux new-session -s zeromq',  get_pty=True)
+        # stdout = client.exec_command(f'tmux new-session -s -d \"zeromq\" python ~/tmp/serial_server.py {self.zmq_port} {self.zmq_timeout} {self.serial_port} {self.serial_baud} {self.serial_timeout} > ~/tmp/serial_server.log')[1]
+        # # client.exec_command('tmux detach')
+        # client.close()
+        # sys.exit(0)
+
+        from fabric import Connection
+        from patchwork.files import exists
+
+        with Connection(f'{server_user}@{server_address}') as c:
+            if not exists(c, "./tmp"):
+               c.run("mkdir ./tmp")
+            c.put(__file__, './tmp/serial_server.py')
+            c.run("tmux new -d -s zeromq")
+            c.run(f"tmux send-keys -t zeromq.0 \"python ~/tmp/serial_server.py {self.zmq_port} {self.zmq_timeout} {self.serial_port} {self.serial_baud} {self.serial_timeout} > ~/tmp/serial_server.log\" ENTER")
+
+    def request(self, command):
+        ''' General-purpose Request-Reply with client
+        
+            Args:
+                command (str): command to execute on server
+            Returns:
+                (str): output of the command on server side
+        '''
+        # Establish connection
+        context = zmq.Context()
+        socket = context.socket(zmq.REQ)
+        socket.connect("tcp://{0}:{1}".format(self.server_address, self.zmq_port))
+
+        try:
+            # Send command
+            socket.send(str.encode(command))
+            # Wait for and return response
+            reply = socket.recv()
+            reply_str = reply.decode()
+        except:
+            reply_str = "Communication failed"
+            pass
+        
+        # Clean communication exit
+        socket.close()
+        context.destroy()
+        return reply_str
+
+
+class ZMQserver():
+    '''
+        Actual class implementing the ZMQ server, to be executed on the remote machine
+    '''
+    def __init__(self, 
+                # ZMQ settings
+                zmq_port=5556, # TCP socket that zmq will use to relay commands
+                zmq_timeout=30, # timeout for server <--> client communication
+                # Serial equipment settings
+                serial_port="/dev/ttyACM0", # Serial port the instrument is connected to on the server (e.g. COM0, "/dev/ttyACM0", etc.)
+                serial_baud=115200, # serial baud rate
+                serial_timeout=5, # timeout for server <--> instrument communication
+            ):
+
+        self.zmq_port = zmq_port
+        self.zmq_timeout = zmq_timeout
+        self.serial_port = serial_port
+        self.serial_baud = serial_baud
+        self.serial_timeout = serial_timeout
+
+        context = zmq.Context()
+        socket = context.socket(zmq.REP)
+        socket.bind(f"tcp://*:{zmq_port}")
+        # Run server
+        self.run(socket)
+        # Clean exit if "run" function is interrupted and returns
+        socket.close()
+        context.destroy()
+
+    def command(self, cmd):
+        cmd += "\n"
+        with serial.Serial(self.serial_port, self.serial_baud, timeout=self.serial_timeout) as ser:
+            ser.write(cmd.encode())
+            recv = ser.readlines()
+            recv_list = []
+            for recvi in recv:
+                recv_list.append(recvi.decode())
+        return recv_list[1]
+
+    def run(self, socket):
+        ''' 
+        Start running the zeromq server on the host machine
+        '''  
+
+        print("Starting server")        
+        try:    
+            while True:
+            
+                cmd = self.zmq_port.recv()
+                print("Received command: %s" % cmd)
+                
+                try:
+                    # Execute command
+                    cmd += "\n"
+                    output = self.command(cmd)
+                    #  Send reply back to client
+                    socket.send(str.encode(output))
+                # If manuel interruption, clean exit
+                except KeyboardInterrupt:
+                    print("Server manually stopped")
+                    return
+                # If communication error
+                except Exception as e:
+                    print("Communication error!")
+                    print(e)
+
+        # If server fails for any other reason (including KeyboardInterrupt)
+        except:
+            # Exit to clean exit command
+            return
+
+
+
+"""
+Code to be executed on the server
+"""
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Process zmq server info')
+    parser.add_argument('zmq_port', type=str, help='Port number for the zmq socket')
+    parser.add_argument('zmq_timeout', type=str, help='Timeout for the zmq socket')
+    parser.add_argument('serial_port', type=str, help='Port address for the serial connection')
+    parser.add_argument('serial_baud', type=str, help='Baud rate for the serial connection')
+    parser.add_argument('serial_timeout', type=str, help='Timeout for the serial connection')
+    args = parser.parse_args()
+
+    server = ZMQserver(zmq_port=args.zmq_port,
+                        zmq_timeout=args.zmq_timeout,
+                        # Serial equipment settings
+                        serial_port=args.serial_port,
+                        serial_baud=args.serial_baud, 
+                        serial_timeout=args.serial_timeout)

--- a/lightlab/equipment/visa_bases/test_serial_server.py
+++ b/lightlab/equipment/visa_bases/test_serial_server.py
@@ -1,0 +1,30 @@
+# zmq
+import time
+import zmq
+
+import numpy as np
+from IPython.display import clear_output
+import serial
+
+import sys
+import os
+
+
+import paramiko
+client = paramiko.SSHClient()
+client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+client.connect('J312pi',
+                    username='pi',
+                    password='lightwavelab')
+# Setup sftp connection and transmit this script
+sftp = client.open_sftp()
+sftp.put(__file__, '/tmp/serial_server.py')
+sftp.close()
+# Run the transmitted script remotely without args and show its output.
+# SSHClient.exec_command() returns the tuple (stdin,stdout,stderr)
+stdout = client.exec_command('python /tmp/serial_server.py')[1]
+for line in stdout:
+    # Process each line in the remote output
+    print line
+client.close()
+sys.exit(0)

--- a/notebooks/remote_zmq_driver.ipynb
+++ b/notebooks/remote_zmq_driver.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Serial communication on remote instruments\n",
+    "\n",
+    "Some instruments support serial communication through USB or RS232 ports. While hubs can extend the number of supported devices, sometimes other limitations such as distance do not allow equipment to be physically connected to a single instrumentation server, complicating experiments.\n",
+    "\n",
+    "Lightlab's solution to this is the \"remote_serial\" driver, a secondary client-server interface that relays commands between a user-controlled \"client\" machine and a remote \"server\" machine that is physically connected to the instrument to be controlled:\n",
+    "\n",
+    "`User ---> [CLIENT e.g. lab instrumentation server] <---ZeroMQ---> [SERVER e.g. Raspberry Pi] <---Serial---> Instrument`\n",
+    "\n",
+    "This is based on the asynchronous messaging platform [ZeroMQ](https://zeromq.org/). A ZMQ server is fast, lightweight, and can ensure continuity between experimental sessions.\n",
+    "\n",
+    "A downside of the ZMQ method is that a server process must be initialized on the server device. This can be automated by Lightlab. When instanciating an instrument with the `remote_serial` interface, the driver first checks if the requested server is already running on the server, and if not, it uses [Fabric](https://www.fabfile.org/index.html) to upload the server code to the server and launch the server. The user only needs to ensure that the device can be found on the network accessible to the client, and note the login credentials and address.\n",
+    "\n",
+    "Current requirements of the remote server:\n",
+    "* Python 3+\n",
+    "* tmux\n",
+    "* (only to launch the server using lightlab) passwordless SSH ability (copy-ssh-id)\n",
+    "\n",
+    "## Example with MDT693B_OLPC driver\n",
+    "\n",
+    "The Thorlabs MDT693B Piezo Controller has a USB interface. We want to control remotely from a central server (in this context, the \"client\"), so we connect it to a Raspberry PI controller (here, the \"server\") which is network-visible to the client.\n",
+    "\n",
+    "The MDT693B_OLPC driver inherits from the ZMQclient class. Instead of a GPIB or Ethernet address, it needs the username and IP address of its controller (here, Raspberry Pi). Note that one full `zmq_timeout` is required to check if the code fails to detect a live server on the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting server 5556 on pi:128.112.50.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "from lightlab.equipment.lab_instruments.MDT693B_OLPC import MDT693B_OLPC\n",
+    "from lightlab.equipment.visa_bases import ZMQclient\n",
+    "\n",
+    "import numpy as np\n",
+    "from IPython.display import clear_output\n",
+    "import serial\n",
+    "\n",
+    "stage = MDT693B_OLPC(name='stage', \n",
+    "                # Server SSH settings\n",
+    "                server_user='pi',\n",
+    "                server_address='128.112.50.75',\n",
+    "                # ZMQ settings\n",
+    "                zmq_port=5556,\n",
+    "                zmq_timeout=15,\n",
+    "                zmq_retries=3,\n",
+    "                server_filename='./tmp/serial_server.py',\n",
+    "                tmux_session_prefix='zmq',\n",
+    "                separator='___',\n",
+    "                # Serial equipment settings\n",
+    "                serial_port=\"/dev/ttyACM0\",\n",
+    "                serial_baud=115200,\n",
+    "                serial_timeout=5,\n",
+    "                        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Server arguments\n",
+    "\n",
+    "The first arguments parametrize the `client` <--> `server` SSH connection.\n",
+    "\n",
+    "`server_address` is the IP address of the server controller.\n",
+    "\n",
+    "`server_user` is the username of the server controller.\n",
+    "\n",
+    "As of now, this scheme requires [passwordless access](https://linuxize.com/post/how-to-setup-passwordless-ssh-login/) from the client to the server. Running `ssh server_user@server_address` should not prompt for a password.\n",
+    "\n",
+    "#### ZMQ arguments\n",
+    "\n",
+    "The zmq arguments parametrize the `client` <--> `server` ZeroMQ (continuous) connection.\n",
+    "\n",
+    "`zmq_port` is the TCP socket that zmq will use to relay commands. If more than one such connection is made to the controller, different values should be used.\n",
+    "\n",
+    "`zmq_timeout` timeout for server <--> client communication\n",
+    "\n",
+    "`zmq_retries` is how many reconnection attempts are performed when a command cannot reach the server.\n",
+    "\n",
+    "`server_filename` is the filename under which the server script is uploaded to the server. Default is `~/tmp/serial_server.py`\n",
+    "\n",
+    "`tmux_session_prefix` is the prefix of the tmux session under which the zmq server is persistently run after severing the SSH connection. By default, it is `zmq`, and results in a full session name `{tmux_session_prefix}_{zmq_port}`.\n",
+    "\n",
+    "`separator` is the delimiting character(s) that separate the command header from the command. By default `___`.\n",
+    "\n",
+    "\n",
+    "#### Serial connection arguments\n",
+    "\n",
+    "The below arguments parametrize the `server` <--> `instrument` connection.\n",
+    "\n",
+    "The `serial_baud` was obtained from the instrument's manual.\n",
+    "\n",
+    "The `serial_port` was found by scanning the controller's USB ports. The below bash script may help:\n",
+    "\n",
+    "```\n",
+    "#!/bin/bash\n",
+    "\n",
+    "for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do\n",
+    "    (\n",
+    "        syspath=\"${sysdevpath%/dev}\"\n",
+    "        devname=\"$(udevadm info -q name -p $syspath)\"\n",
+    "        [[ \"$devname\" == \"bus/\"* ]] && exit\n",
+    "        eval \"$(udevadm info -q property --export -p $syspath)\"\n",
+    "        [[ -z \"$ID_SERIAL\" ]] && exit\n",
+    "        echo \"/dev/$devname - $ID_SERIAL\"\n",
+    "    )\n",
+    "done\n",
+    "```\n",
+    "\n",
+    "The timeouts are made high enough to ensure reliable communication (trial and error might be required here)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Driver-level operation\n",
+    "\n",
+    "Since MDT693B_OLPC inherits from the ZMQclient class, its driver functions can directly call the `request`, `write`, etc. method. Hence, a programmer only needs to translate serial commands from the MDT693B like so:\n",
+    "\n",
+    "```\n",
+    "def get_volt(self, axis):\n",
+    "    cmd = \"{}voltage?\".format(axis)\n",
+    "    ans = self.request(cmd)\n",
+    "    return float(ans.strip('[]\\r> '))\n",
+    "```\n",
+    "\n",
+    "Here, the `cmd` to read the voltage was lifted from the instrument programming manual. The `request` method from `ZMQclient`, via the instanciated `ZMQserver` instanciated on the controller, will pass the string command to the instrument and return the result. The user then only needs to parse as required by the instrument response. There is also a `write` method which sends messages to the instrument without waiting for a response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12.05"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stage.get_volt('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stage.set_volt('x', 15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "15.04"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stage.get_volt('x')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stage.terminate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we have terminated the server (which should not really be required), below is a timeout (need to improve error handling):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ZMQError",
+     "evalue": "Operation not supported",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mZMQError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-b731a4c71e4f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mstage\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_volt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'x'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Github/lightlab/lightlab/equipment/lab_instruments/MDT693B_OLPC.py\u001b[0m in \u001b[0;36mget_volt\u001b[0;34m(self, axis)\u001b[0m\n\u001b[1;32m     38\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_volt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m         \u001b[0mcmd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"{}voltage?\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 40\u001b[0;31m         \u001b[0mans\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrequest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcmd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     41\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mfloat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mans\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstrip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'[]\\r> '\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Github/lightlab/lightlab/equipment/visa_bases/remote_serial_driver.py\u001b[0m in \u001b[0;36mrequest\u001b[0;34m(self, command, header)\u001b[0m\n\u001b[1;32m    133\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    134\u001b[0m             \u001b[0;31m# If get an answer:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 135\u001b[0;31m             \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpoll\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mzmq_timeout\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0;36m1000\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m&\u001b[0m \u001b[0mzmq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPOLLIN\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    136\u001b[0m                 \u001b[0;31m# Wait for and return response\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    137\u001b[0m                 \u001b[0mreply\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msocket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/miniconda3/envs/lightlab/lib/python3.7/site-packages/zmq/sugar/socket.py\u001b[0m in \u001b[0;36mpoll\u001b[0;34m(self, timeout, flags)\u001b[0m\n\u001b[1;32m    691\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    692\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclosed\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 693\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mZMQError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mENOTSUP\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    694\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    695\u001b[0m         \u001b[0mp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_poller_class\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mZMQError\u001b[0m: Operation not supported"
+     ]
+    }
+   ],
+   "source": [
+    "stage.get_volt('x')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Under the hood\n",
+    "\n",
+    "The ZMQ client <--> server purely exchanges messages, and so details are left to the programmer. Here, the `client` attempts to send messages to a continuously-listening `server` (through its `run` method), and waits for a response. Some amount of message parsing is done at the `server` level through alphanumeric `cmd_header` values appended at the beginning of the communication, parsed through the `separator` argument. This allows some commands to not be relayed to the connected instrument and trigger something on the server itself (such as `ping`, `terminate`, etc.), or to alter the behaviour of the serial communication (for instance, `request` having along timeout to wait for responses, and `write` having a short one). There may be more robust ways to do this, for instance with sequences of messages."
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "10e33293ef4e883f40babe4d6b690470d45e57e0241ac34d69dfde204a74e2b3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.6.13 ('lightlab': conda)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_zmq_drivers.py
+++ b/tests/test_zmq_drivers.py
@@ -1,0 +1,9 @@
+''' Creates local zmq client and servers and tests functionality'''
+
+import pytest
+from mock import patch
+from lightlab.equipment import lab_instruments
+from lightlab.equipment.lab_instruments import VISAInstrumentDriver
+import inspect
+
+# TODO


### PR DESCRIPTION
New driver class for serial connections that occur through an intermediate server, for instance

User <--> Client (e.g. instrumentation server) <--ZMQ--> Server/controller (e.g. Raspberry PI) <--Serial/USB--> Instrument

There is also an example of a driver leveraging this (MDT693B, Thorlabs Piezo Controller)

As described in the example notebook, the user experience is setup to be **identical** to other lightlab drivers. The user only needs to connect the server/controller machine to the instrument, and setup passwordless SSH access from the client machine to it. Then, for the user it is as if the instrument is directly connected to the client, with simple execution such as

```
    stage = MDT693B_OLPC(name='stage', server_address='IP_address', server_user='pi')
    print(stage.set_volt('x', 12)) # outputs 1 for successful upload
    print(stage.get_volt('x')) # outputs 12
```

This is enabled by the fact that, when instanciating an instrument subclassed from this driver type, ZMQ server code is automatically uploaded and then persistently executed on the server/controller. The client can then use ZMQclient methods such as `request` and `write` to send commands to the instrument, relayed through the server/controller.

TODO:

* Allow non-passwordless connections between client and server/controller. Since there is only one SSH connection during instanciation, it would be nice to have the option to just provide a password once there (like Paramiko allows).
* Add hardware-free unit test, maybe spawing client/server on localhost with a dummy instrument.
* Add better logging, need to decide what to do about server vs client logging, since user presumably only