### PR TITLE
fixed pcolormesh shading errors during lightcal tests

### DIFF
--- a/lightlab/util/data/two_dim.py
+++ b/lightlab/util/data/two_dim.py
@@ -520,7 +520,7 @@ class MeasuredSurface(object):
         if 'cmap' not in kwargs.keys():
             kwargs['cmap'] = cm.inferno  # pylint: disable=no-member
         if 'shading' not in kwargs.keys():
-            kwargs['shading'] = 'flat'
+            kwargs['shading'] = 'gouraud'
         YY, XX = np.meshgrid(self.absc[0], self.absc[1])
         plt.pcolormesh(XX, YY, np.array(self.ordi.T), *args, **kwargs)
         plt.autoscale(tight=True)


### PR DESCRIPTION
I ran into some errors running `make test-sim` in lightcal: `MeasuredSurface.simplePlot` raised a `TypeError` in `plt.pcolormesh` on line 525 that I tracked down to the shading argument. The `X` and `Y` arguments in `plt.pcolormesh` should have size one greater than `C` when using flat shading; Matplotlib docs say that this should only be raising a warning rather than an error but @atait suggested we just change it to gouraud shading to avoid the problem.

An alternative solution would be to alter the call to `meshgrid` on line 524.