### PR TITLE
fix PNA defualting to S21 bug

### DIFF
--- a/lightlab/equipment/lab_instruments/Agilent_N5222A_NA.py
+++ b/lightlab/equipment/lab_instruments/Agilent_N5222A_NA.py
@@ -36,9 +36,10 @@ class Agilent_N5222A_NA(VISAInstrumentDriver, Configurable):
         self.traceNum = 1
         self.auxTrigNum = 1
         self.swpRange = None
+        self.measType = 'S21'
 
     def startup(self):
-        self.measurementSetup('S21')
+        self.measurementSetup(self.measType)
 
     def amplitude(self, amp=None):
         ''' Amplitude is in dBm
@@ -183,20 +184,25 @@ class Agilent_N5222A_NA(VISAInstrumentDriver, Configurable):
             changed = True
         self.setConfigParam('CALC{}:PAR:MNUM'.format(self.chanNum),
                             self.chanNum, forceHardware=changed)
+
+        retStr = self.query('CALC{}:PAR:CAT:EXT?'.format(chanNum)).strip('"')
         # self.setConfigParam('CALC{}:PAR:SEL'.format(self.chanNum), self.chanNum, forceHardware=changed)
         # wait for changes to take effect
         # This could be improved by something like *OPC? corresponding to the end
         # of the first sweep
         time.sleep(self.getSwpDuration())
+        self.measType = measType
 
     def spectrum(self):
         # raise NotImplementedError('not working')
         # self.setConfigParam('SENS:SWE:GRO:COUN', nGroups)
+
         self.setConfigParam('SENS:SWE:MODE', 'HOLD')
         self.write('SENS:SWE:MODE SING')
         self.query('*OPC?')
 
         self.setConfigParam('FORM', 'ASC')
+
         self.open()
         dbm = self.query_ascii_values('CALC{}:DATA? FDATA'.format(self.chanNum))
         self.close()


### PR DESCRIPTION
Added attribute to PNA driver so that self.startup during acquisition does not default to S21 regardless of previously-ran measurementSetup